### PR TITLE
Adding support for the infinity point

### DIFF
--- a/src/PyECCArithmetic/point.py
+++ b/src/PyECCArithmetic/point.py
@@ -107,6 +107,20 @@ class Point(object):
             self._isOnCurve = ((self.y ** 2) % self.curve.p) == (self.x ** 3 + self.curve.a * self.x + self.curve.b) % self.curve.p
         return self._isOnCurve
 
+    
+    def isOnSameCurveAs(self, other):
+        """
+        Checks if *self* is on the same curve as *other*. The point of infinity is part of every curve.
+        :param other: Another point
+        :type other: Point
+        :return: True or False
+        :rtype: bool
+        """
+        if self.isInfinityPoint or other.isInfinityPoint:
+            return True
+        else:
+            return self.curve == other.curve
+
 
     def calcOrder(self, timeout=10):
         """
@@ -144,9 +158,9 @@ class Point(object):
         """
         if not isinstance(other, Point):
             raise ValueError('First argument has to be a Point')
-        if self.curve != other.curve:
+        elif not self.isOnSameCurveAs(other):
             raise PointsOnDifferentCurveError()
-        if self.isInfinityPoint or other.isInfinityPoint:
+        elif self.isInfinityPoint or other.isInfinityPoint:
             return self == other
         else:
             return self.x == other.x and self.y == (-other.y % self.curve.p)
@@ -184,7 +198,7 @@ class Point(object):
         :return: new_point = self + other
         :rtype: Point
         """
-        if self.curve != other.curve:
+        if not self.isOnSameCurveAs(other):
             raise PointsOnDifferentCurveError()
 
         if self.isInfinityPoint:

--- a/src/PyECCArithmetic/point.py
+++ b/src/PyECCArithmetic/point.py
@@ -75,6 +75,11 @@ class Point(object):
         return self._x is None and self._y is None
 
 
+    @staticmethod
+    def infinity():
+        return Point(None, None)
+
+
     @property
     def isOnCurve(self):
         """

--- a/src/PyECCArithmetic/point.py
+++ b/src/PyECCArithmetic/point.py
@@ -30,11 +30,13 @@ class Point(object):
         self._curve = curve
         self._order = None
         self._isOnCurve = None
+        self._isInfinityPoint = None
 
 
     def _reset(self):
         self._order = None
         self._isOnCurve = None
+        self._isInfinityPoint = None
 
 
     @property
@@ -72,7 +74,16 @@ class Point(object):
 
     @property
     def isInfinityPoint(self):
-        return self._x is None and self._y is None
+        """
+        Checks if a point is the infinity point that is contained in every curve.
+        :return: True or False
+        :rtype: bool
+        """
+        if self._isInfinityPoint is not None:
+            return self._isInfinityPoint
+        else:
+            self._isInfinityPoint = (self._x is None and self._y is None)
+        return self._isInfinityPoint
 
 
     @staticmethod

--- a/src/PyECCArithmetic/point.py
+++ b/src/PyECCArithmetic/point.py
@@ -82,7 +82,7 @@ class Point(object):
         if self._isInfinityPoint is not None:
             return self._isInfinityPoint
         else:
-            self._isInfinityPoint = (self._x is None and self._y is None)
+            self._isInfinityPoint = self == Point.infinity()
         return self._isInfinityPoint
 
 
@@ -159,7 +159,7 @@ class Point(object):
         :rtype: Point
         """
         if self.isInfinityPoint:
-            return Point(None, None, self.curve)
+            return Point.infinity()
         else:
             return Point(self.x, (-self.y % self.curve.p), self.curve)
 
@@ -193,7 +193,7 @@ class Point(object):
             return self.__copy__()
 
         if self.x == other.x and self.y == -other.y % self.curve.p:
-            return Point(None, None, self.curve)
+            return Point.infinity()
 
         if self == other:
             s = ((3 * self.x ** 2 + self.curve.a) * _mul_inv(2 * self.y, self.curve.p)) % self.curve.p

--- a/tests.py
+++ b/tests.py
@@ -7,8 +7,8 @@ from PyECCArithmetic import *
 class TestECC_SmallCurve(unittest.TestCase):
 
     def setUp(self):
-        x_coords = [5, 6, 10, 3, 9, 16, 0, 13, 7, 7, 13, 0, 16, 9, 3, 10, 6, 5]
-        y_coords = [1, 3, 6, 1, 16, 13, 6, 7, 6, 11, 10, 11, 4, 1, 16, 11, 14, 16]
+        x_coords = [5, 6, 10, 3,  9, 16, 0, 13, 7,  7, 13,  0, 16, 9,  3, 10,  6,  5]
+        y_coords = [1, 3,  6, 1, 16, 13, 6,  7, 6, 11, 10, 11,  4, 1, 16, 11, 14, 16]
         self.curve = Curve(2, 2, 17, "test")
         self.results = [Point(x, y, self.curve) for x, y in zip(x_coords, y_coords)]
         self.pointOrder = 19
@@ -21,6 +21,21 @@ class TestECC_SmallCurve(unittest.TestCase):
         for i in range(1, len(self.results)):
             temp = temp + P
             self.assertEqual(self.results[i], temp)
+
+
+    def test_infinity(self):
+        P = self.results[0]
+        o = Point(None, None, self.curve)
+
+        self.assertFalse(P.isInfinityPoint)
+        self.assertTrue(o.isInfinityPoint)
+        self.assertTrue(o.isOnCurve)
+        self.assertEqual(o, P - P)
+        self.assertEqual(P, P + o)
+        self.assertEqual(P, o + P)
+        self.assertEqual(o, o.inverse())
+        self.assertTrue(o.isInverseOf(o))
+        self.assertFalse(o.isInverseOf(P))
 
 
     def test_mul(self):
@@ -142,4 +157,4 @@ class TestECC_General(unittest.TestCase):
         self.P2.curve = self.curve1
 
         with self.assertRaises(TimeoutError):
-            self.P2.calcOrder(timeout=0.5)
+            self.P2.calcOrder(timeout=0.1)

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,14 @@ class TestECC_SmallCurve(unittest.TestCase):
         self.assertNotEqual(o, Point.infinity())
 
 
+    def test_infinityCalculation(self):
+        P = self.results[0]
+        
+        self.assertEqual(P * self.pointOrder, Point.infinity())
+        self.assertEqual(P * (self.pointOrder + 1), P)
+        self.assertEqual(P * (self.pointOrder - 1), -P)
+
+
     def test_mul(self):
         P = self.results[0]
 

--- a/tests.py
+++ b/tests.py
@@ -25,7 +25,7 @@ class TestECC_SmallCurve(unittest.TestCase):
 
     def test_infinity(self):
         P = self.results[0]
-        o = Point(None, None, self.curve)
+        o = Point.infinity()
 
         # o is the infinity point, P is not
         self.assertFalse(P.isInfinityPoint)

--- a/tests.py
+++ b/tests.py
@@ -27,8 +27,10 @@ class TestECC_SmallCurve(unittest.TestCase):
         P = self.results[0]
         o = Point(None, None, self.curve)
 
+        # o is the infinity point, P is not
         self.assertFalse(P.isInfinityPoint)
         self.assertTrue(o.isInfinityPoint)
+        self.assertEqual(o, Point.infinity())
         self.assertTrue(o.isOnCurve)
         self.assertEqual(o, P - P)
         self.assertEqual(P, P + o)
@@ -36,6 +38,11 @@ class TestECC_SmallCurve(unittest.TestCase):
         self.assertEqual(o, o.inverse())
         self.assertTrue(o.isInverseOf(o))
         self.assertFalse(o.isInverseOf(P))
+
+        # Changing o should not affect the staticmethod Point.infinity()
+        o.x = 42
+        self.assertFalse(o.isInfinityPoint)
+        self.assertNotEqual(o, Point.infinity())
 
 
     def test_mul(self):


### PR DESCRIPTION
Every Elliptic Curve _E_ over a finite field contains the infinity point _O_ that satisfies
(a) _P_ + _O_ = _O_ + _P_ = _P_ for all points _P_ in _E_
(b) _P_ + (-_P_) = _O_ for all points _P_ in _E_

I added support for the infinity point into the library as the object `Point(None, None, curve)` and edited the code in a backwards-compatible way along with new tests. 

I appreciate your time reviewing this PR and if you end up accepting it then I suggest bumping the version to `1.1.0`.